### PR TITLE
Added state to `Task`

### DIFF
--- a/hyperloop/Cargo.toml
+++ b/hyperloop/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 futures = {version = "0.3.15", default-features = false}
 embedded-time = "0.12.0"
+atomig = {version = "0.3.2", features = ["derive"]}
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
#6 

- Each Task should only have one entry in the executor queue, and if
  the task is already queued `wake()` should do nothing.