### PR TITLE
Use correct ordering for atomics in priority queue and test with loom

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,3 +22,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Loom tests
+      run: RUSTFLAGS="--cfg loom" cargo test --release tests_loom

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@
 members = [
     "hyperloop",
     "hyperloop-macros",
+    "hyperloop-priority-queue",
 ]

--- a/hyperloop-priority-queue/Cargo.toml
+++ b/hyperloop-priority-queue/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hyperloop-priority-queue"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+atomig = {version = "0.3.2", features = ["derive"]}
+crossbeam-utils = "0.8.5"
+
+[dev-dependencies.crossbeam-queue]
+version = "0.3"

--- a/hyperloop-priority-queue/Cargo.toml
+++ b/hyperloop-priority-queue/Cargo.toml
@@ -9,5 +9,8 @@ edition = "2021"
 atomig = {version = "0.3.2", features = ["derive"]}
 crossbeam-utils = "0.8.5"
 
+[target.'cfg(loom)'.dependencies]
+loom =  "0.5.4"
+
 [dev-dependencies.crossbeam-queue]
 version = "0.3"

--- a/hyperloop-priority-queue/src/lib.rs
+++ b/hyperloop-priority-queue/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use core::{
     marker::PhantomData,
     ops::Deref,
@@ -485,12 +487,14 @@ where
 }
 
 #[cfg(test)]
+#[macro_use]
+extern crate std;
+
+#[cfg(test)]
 mod tests {
     use std::thread;
 
     use std::vec::Vec;
-
-    use crate::common::tests::log_init;
 
     use super::*;
 
@@ -596,8 +600,6 @@ mod tests {
 
     #[test]
     fn channel_thread() {
-        log_init();
-
         const N: usize = 1000;
         let mut queue: PriorityQueue<u128, Min, N> = PriorityQueue::new();
         let mut handlers = Vec::new();

--- a/hyperloop-priority-queue/src/lib.rs
+++ b/hyperloop-priority-queue/src/lib.rs
@@ -182,12 +182,12 @@ impl AtomicStackPosition {
     }
 
     fn load(&self) -> StackPosition {
-        StackPosition::new(self.atomic.load(Ordering::Relaxed))
+        StackPosition::new(self.atomic.load(Ordering::Acquire))
     }
 
     fn compare_exchange(&self, current: usize, new: usize) -> Result<usize, usize> {
         self.atomic
-            .compare_exchange(current, new, Ordering::Relaxed, Ordering::Relaxed)
+            .compare_exchange_weak(current, new, Ordering::Release, Ordering::Relaxed)
     }
 }
 
@@ -249,13 +249,13 @@ impl<T> PrioritySender<T> {
 
     pub fn send(&self, item: T) -> Result<(), T> {
         loop {
-            let available = self.available.load(Ordering::Relaxed);
+            let available = self.available.load(Ordering::Acquire);
 
             if available > 0 {
                 if let Ok(_) = self.available.compare_exchange(
                     available,
                     available - 1,
-                    Ordering::Relaxed,
+                    Ordering::Release,
                     Ordering::Relaxed,
                 ) {
                     break;
@@ -471,12 +471,12 @@ where
 
         if let Some(item) = self.heap_pop() {
             loop {
-                let available = self.available.load(Ordering::Relaxed);
+                let available = self.available.load(Ordering::Acquire);
 
                 if let Ok(_) = self.available.compare_exchange(
                     available,
                     available + 1,
-                    Ordering::Relaxed,
+                    Ordering::Release,
                     Ordering::Relaxed,
                 ) {
                     break Some(item);

--- a/hyperloop/Cargo.toml
+++ b/hyperloop/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 futures = {version = "0.3.15", default-features = false}
 embedded-time = "0.12.0"
 atomig = {version = "0.3.2", features = ["derive"]}
-crossbeam-utils = "0.8.5"
+hyperloop-priority-queue = {path = "../hyperloop-priority-queue"}
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/hyperloop/src/lib.rs
+++ b/hyperloop/src/lib.rs
@@ -4,13 +4,16 @@
 #![feature(once_cell)]
 
 mod common;
-mod priority_queue;
 
 pub mod executor;
 pub mod interrupt;
 pub mod notify;
 pub mod task;
 pub mod timer;
+
+mod priority_queue {
+    pub(crate) use hyperloop_priority_queue::*;
+}
 
 #[macro_use]
 extern crate std;


### PR DESCRIPTION
Finally got around to learning what the ordering argument of atomic operations are all about.