### PR TITLE
Ensure static executor and timer

### DIFF
--- a/hyperloop-macros/src/lib.rs
+++ b/hyperloop-macros/src/lib.rs
@@ -143,7 +143,7 @@ pub fn executor_from_tasks(tokens: TokenStream) -> TokenStream {
             static mut EXECUTOR: Option<Executor<#n_tasks>> = None;
 
             let executor = unsafe {
-                EXECUTOR.get_or_insert(Executor::new())
+                EXECUTOR.get_or_insert(Executor::new()).get_ref()
             };
 
             #tasks

--- a/hyperloop/src/executor.rs
+++ b/hyperloop/src/executor.rs
@@ -70,7 +70,7 @@ impl<const N: usize> Executor<N> {
         }
     }
 
-    fn get_sender(&self) -> TaskSender {
+    unsafe fn get_sender(&self) -> TaskSender {
         self.queue.get_sender()
     }
 
@@ -96,7 +96,7 @@ impl<const N: usize> ExecutorRef<N> {
     }
 
     pub fn get_sender(&self) -> TaskSender {
-        self.executor.get_sender()
+        unsafe { self.executor.get_sender() }
     }
 }
 

--- a/hyperloop/src/executor.rs
+++ b/hyperloop/src/executor.rs
@@ -64,21 +64,46 @@ impl<const N: usize> Executor<N> {
     /// pointers to the tasks stored in the executor. The pointers can
     /// be dereferenced at any time and will be dangling if the
     /// exeutor is moved or dropped.
-    pub unsafe fn poll_tasks(&mut self) {
+    unsafe fn poll_tasks(&mut self) {
         while let Some(ticket) = self.queue.pop() {
             let _ = ticket.get_task().poll();
         }
     }
 
-    pub fn get_sender(&self) -> TaskSender {
+    fn get_sender(&self) -> TaskSender {
         self.queue.get_sender()
+    }
+
+    pub fn get_ref(&'static mut self) -> ExecutorRef<N> {
+        ExecutorRef::new(self)
+    }
+}
+
+/// Wrapper around Executor to allow safe polling
+pub struct ExecutorRef<const N: usize> {
+    executor: &'static mut Executor<N>,
+}
+
+impl<const N: usize> ExecutorRef<N> {
+    fn new(executor: &'static mut Executor<N>) -> Self {
+        Self { executor }
+    }
+
+    pub fn poll_tasks(&mut self) {
+        unsafe {
+            self.executor.poll_tasks();
+        }
+    }
+
+    pub fn get_sender(&self) -> TaskSender {
+        self.executor.get_sender()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crossbeam_queue::ArrayQueue;
-    use hyperloop_macros::{executor_from_tasks, task};
+    use std::boxed::Box;
     use std::sync::Arc;
 
     use super::*;
@@ -86,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_executor() {
-        let mut executor = Executor::<10>::new();
+        let mut executor = Box::leak(Box::new(Executor::<10>::new())).get_ref();
         let queue = Arc::new(ArrayQueue::new(10));
 
         let test_future = |queue, value| {
@@ -109,40 +134,11 @@ mod tests {
         task3.add_to_executor(executor.get_sender()).unwrap();
         task4.add_to_executor(executor.get_sender()).unwrap();
 
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop().unwrap(), 4);
         assert_eq!(queue.pop().unwrap(), 2);
         assert_eq!(queue.pop().unwrap(), 3);
-        assert_eq!(queue.pop().unwrap(), 1);
-    }
-
-    #[test]
-    fn macros() {
-        #[task(priority = 1)]
-        async fn test_task1(queue: Arc<ArrayQueue<u32>>) {
-            queue.push(1).unwrap();
-        }
-
-        #[task(priority = 2)]
-        async fn test_task2(queue: Arc<ArrayQueue<u32>>) {
-            queue.push(2).unwrap();
-        }
-
-        let queue = Arc::new(ArrayQueue::new(10));
-
-        let task1 = test_task1(queue.clone()).unwrap();
-        let task2 = test_task2(queue.clone()).unwrap();
-
-        let executor = executor_from_tasks!(task1, task2);
-
-        unsafe {
-            executor.poll_tasks();
-        }
-
-        assert_eq!(queue.pop().unwrap(), 2);
         assert_eq!(queue.pop().unwrap(), 1);
     }
 }

--- a/hyperloop/src/lib.rs
+++ b/hyperloop/src/lib.rs
@@ -17,3 +17,37 @@ mod priority_queue {
 
 #[macro_use]
 extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use crate::executor::Executor;
+    use crate::task::Task;
+    use crossbeam_queue::ArrayQueue;
+    use hyperloop_macros::{executor_from_tasks, task};
+    use std::sync::Arc;
+
+    #[test]
+    fn macros() {
+        #[task(priority = 1)]
+        async fn test_task1(queue: Arc<ArrayQueue<u32>>) {
+            queue.push(1).unwrap();
+        }
+
+        #[task(priority = 2)]
+        async fn test_task2(queue: Arc<ArrayQueue<u32>>) {
+            queue.push(2).unwrap();
+        }
+
+        let queue = Arc::new(ArrayQueue::new(10));
+
+        let task1 = test_task1(queue.clone()).unwrap();
+        let task2 = test_task2(queue.clone()).unwrap();
+
+        let mut executor = executor_from_tasks!(task1, task2);
+
+        executor.poll_tasks();
+
+        assert_eq!(queue.pop().unwrap(), 2);
+        assert_eq!(queue.pop().unwrap(), 1);
+    }
+}

--- a/hyperloop/src/notify.rs
+++ b/hyperloop/src/notify.rs
@@ -72,7 +72,7 @@ mod tests {
     fn notify() {
         let notification = Box::leak(Box::new(Notification::new()));
 
-        let mut executor = Executor::<10>::new();
+        let mut executor = Box::leak(Box::new(Executor::<10>::new())).get_ref();
         let queue = Arc::new(ArrayQueue::new(10));
 
         let wait = |receiver, queue| {
@@ -92,39 +92,28 @@ mod tests {
 
         task1.add_to_executor(executor.get_sender()).unwrap();
 
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(1));
         assert_eq!(queue.pop(), None);
 
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), None);
 
         notification.notify();
-
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(2));
         assert_eq!(queue.pop(), None);
 
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), None);
 
         notification.notify();
 
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(3));
         assert_eq!(queue.pop(), None);

--- a/hyperloop/src/task.rs
+++ b/hyperloop/src/task.rs
@@ -150,6 +150,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::boxed::Box;
+
     use crate::{
         interrupt::yield_now,
         priority_queue::{Max, PriorityQueue},
@@ -159,7 +161,8 @@ mod tests {
 
     #[test]
     fn task() {
-        let mut queue: PriorityQueue<Ticket, Max, 1> = PriorityQueue::new();
+        let queue: &'static mut PriorityQueue<Ticket, Max, 1> =
+            Box::leak(Box::new(PriorityQueue::new()));
 
         let test_future = || {
             || {
@@ -175,7 +178,7 @@ mod tests {
 
         let task = Task::new(test_future(), 1);
 
-        task.set_sender(queue.get_sender()).unwrap();
+        task.set_sender(unsafe { queue.get_sender() }).unwrap();
 
         assert_eq!(task.get_state(), TaskState::NotQueued);
 

--- a/hyperloop/src/timer.rs
+++ b/hyperloop/src/timer.rs
@@ -428,7 +428,7 @@ mod tests {
         let scheduler: &'static mut Scheduler<10> =
             Box::leak(Box::new(Scheduler::new(1000.Hz(), token.clone())));
         let timer = scheduler.get_timer();
-        let mut executor = Box::new(Executor::<10>::new());
+        let mut executor = Box::leak(Box::new(Executor::<10>::new())).get_ref();
         let queue = Arc::new(ArrayQueue::new(10));
 
         log_init();
@@ -469,9 +469,7 @@ mod tests {
         task1.add_to_executor(executor.get_sender()).unwrap();
         task2.add_to_executor(executor.get_sender()).unwrap();
 
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(1));
         assert_eq!(queue.pop(), None);
@@ -479,17 +477,13 @@ mod tests {
         unsafe {
             counter.tick();
         }
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(2));
         assert_eq!(queue.pop(), None);
 
         counter.wake();
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), None);
 
@@ -499,9 +493,7 @@ mod tests {
         unsafe {
             counter.tick();
         }
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(3));
         assert_eq!(queue.pop(), None);
@@ -512,9 +504,7 @@ mod tests {
         unsafe {
             counter.tick();
         }
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(4));
         assert_eq!(queue.pop(), None);
@@ -525,9 +515,7 @@ mod tests {
         unsafe {
             counter.tick();
         }
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(5));
         assert_eq!(queue.pop(), None);
@@ -536,9 +524,7 @@ mod tests {
             unsafe {
                 counter.tick();
             }
-            unsafe {
-                executor.poll_tasks();
-            }
+            executor.poll_tasks();
 
             assert_eq!(queue.pop(), None);
         }
@@ -546,9 +532,7 @@ mod tests {
         unsafe {
             counter.tick();
         }
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(6));
         assert_eq!(queue.pop(), None);
@@ -561,7 +545,7 @@ mod tests {
         let scheduler: &'static mut Scheduler<10> =
             Box::leak(Box::new(Scheduler::new(1000.Hz(), token.clone())));
         let timer = scheduler.get_timer();
-        let mut executor = Executor::<10>::new();
+        let mut executor = Box::leak(Box::new(Executor::<10>::new())).get_ref();
         let queue = Arc::new(ArrayQueue::new(10));
 
         log_init();
@@ -601,9 +585,7 @@ mod tests {
         task1.add_to_executor(executor.get_sender()).unwrap();
         task2.add_to_executor(executor.get_sender()).unwrap();
 
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(1));
         assert_eq!(queue.pop(), None);
@@ -616,9 +598,7 @@ mod tests {
 
         counter.wake();
 
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(2));
         assert_eq!(queue.pop(), None);
@@ -629,9 +609,7 @@ mod tests {
             }
             counter.wake();
 
-            unsafe {
-                executor.poll_tasks();
-            }
+            executor.poll_tasks();
 
             assert_eq!(queue.pop(), None);
         }
@@ -641,9 +619,7 @@ mod tests {
         }
         counter.wake();
 
-        unsafe {
-            executor.poll_tasks();
-        }
+        executor.poll_tasks();
 
         assert_eq!(queue.pop(), Some(3));
         assert_eq!(queue.pop(), None);

--- a/hyperloop/src/timer.rs
+++ b/hyperloop/src/timer.rs
@@ -302,7 +302,7 @@ impl<const N: usize> Scheduler<N> {
         }
     }
 
-    pub fn get_timer(&self) -> Timer {
+    pub unsafe fn get_timer(&self) -> Timer {
         Timer::new(self.rate, self.counter.clone(), self.queue.get_sender())
     }
 
@@ -379,7 +379,7 @@ mod tests {
         let token = counter.get_token();
         let scheduler: &'static mut Scheduler<10> =
             Box::leak(Box::new(Scheduler::new(1000.Hz(), token.clone())));
-        let sender = scheduler.queue.get_sender();
+        let sender = unsafe { scheduler.queue.get_sender() };
         let mockwaker = Arc::new(MockWaker::new());
         let waker: Waker = mockwaker.clone().into();
         let mut cx = Context::from_waker(&waker);
@@ -427,7 +427,7 @@ mod tests {
         let token = counter.get_token();
         let scheduler: &'static mut Scheduler<10> =
             Box::leak(Box::new(Scheduler::new(1000.Hz(), token.clone())));
-        let timer = scheduler.get_timer();
+        let timer = unsafe { scheduler.get_timer() };
         let mut executor = Box::leak(Box::new(Executor::<10>::new())).get_ref();
         let queue = Arc::new(ArrayQueue::new(10));
 
@@ -544,7 +544,7 @@ mod tests {
         let token = counter.get_token();
         let scheduler: &'static mut Scheduler<10> =
             Box::leak(Box::new(Scheduler::new(1000.Hz(), token.clone())));
-        let timer = scheduler.get_timer();
+        let timer = unsafe { scheduler.get_timer() };
         let mut executor = Box::leak(Box::new(Executor::<10>::new())).get_ref();
         let queue = Arc::new(ArrayQueue::new(10));
 


### PR DESCRIPTION
The priority queue used by the executor and timer is only safe if it is static. Because of this, functions such as polling tasks are now unsafe. By wrapping the executor in a struct that holds a static reference, we can safely call the unsafe functions from the wrapper:

```Rust
impl ShouldBeStatic {
    unsafe fn danger(&mut self) {
        do_unsafe_stuff_that_is_fine_if_static();
    }
}

struct ShoudBeStaticRef {
    target: &'static mut ShouldBeStatic,
}

impl ShouldBeStaticRef {
    fn danger(&mut self) {
        unsafe { self.target.danger(); }
    }
}

```